### PR TITLE
possible fix for buffer overflow & fix for slash in peername & entries addet to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ bin/
 build/
 autom4te.cache/
 Makefile
+*config.log
+*config.status

--- a/src/tg_data.c
+++ b/src/tg_data.c
@@ -88,7 +88,7 @@ void tg_print_peer_t(tg_peer_t* peer) {
 #endif
 
 void tg_peer_search_msg_count(tg_peer_t* peer) {
-	if(strlen(peer->print_name) > 0) {
+	if(strlen(peer->peer_name) > 0) {
 		printf("Try to count peer %s\n", peer->print_name);
 		size_t l = 0, r = 130000;
 		size_t middle;
@@ -97,7 +97,7 @@ void tg_peer_search_msg_count(tg_peer_t* peer) {
 		size_t size = 0;
 		while(l + 1 < r) {
 			middle = (l + r) / 2;
-			sprintf(str, "history %s 1 %li\n", peer->print_name, middle);
+			sprintf(str, "history %s 1 %li\n", peer->peer_name, middle);
 			printf("debug: %s", str);
 			socket_send_string(str, strlen(str));
 			socket_read_data(&data, &size); 
@@ -301,7 +301,7 @@ int tg_search_msg(tg_peer_t* peer, const int media_type, const char* request) {
 	result = 2;
 	time_t start_time = time(NULL) - 60;
 	while(result > 1) {
-		sprintf(str, "search %s %i %i 0 0 %i %s\n", peer->print_name, media_type, count, offset, request);
+		sprintf(str, "search %s %i %i 0 0 %i %s\n", peer->peer_name, media_type, count, offset, request);
 		
 		pthread_mutex_lock(&lock);
 		socket_send_string(str, strlen(str));
@@ -311,7 +311,7 @@ int tg_search_msg(tg_peer_t* peer, const int media_type, const char* request) {
 		assert(json);
 		result = json_parse_messages(json, len, peer, media_type);
 #ifdef DEBUG
-		printf("tg_search_msg(%s, %i) = %i\n", peer->print_name, offset, result);
+		printf("tg_search_msg(%s, %i) = %i\n", peer->peer_name, offset, result);
 #endif
 		offset += count;
 		free(json);

--- a/src/tg_data.h
+++ b/src/tg_data.h
@@ -44,6 +44,7 @@ typedef struct {
 	uint64_t peer_id;
 	
 	char* print_name;
+	char* peer_name;
 	uint32_t print_name_hash;
 	
 	time_t last_seen;

--- a/src/tgfs.c
+++ b/src/tgfs.c
@@ -334,6 +334,8 @@ int tgfs_release(const char *path, struct fuse_file_info *fi) {
 			
 		strncpy(buff, path + 1, s - 1);
 		buff[s-1] = 0;
+		tg_peer_t* peer = tg_find_peer_by_name(buff, strlen(buff));
+		strcpy(buff, peer->peer_name);
 		if(n == 3) {
 			int media_type = tg_get_media_type_by_string(path + c[1]);
 			switch(media_type) {

--- a/src/tgfs.c
+++ b/src/tgfs.c
@@ -38,7 +38,7 @@ tg_fd* tgfs_fd = NULL;
 static int slashes_to_index_array(size_t* a, const char *path) {
 	size_t n = 0;
 	for(size_t i = 0; i < strlen(path); i++) {
-		if(path[i] == '/') {
+		if(path[i] == '/' && n < PATH_MAX_LEVEL - 1) {
 			a[n] = i + 1;
 			n++;
 		}


### PR DESCRIPTION
Possible buffer overflow in static int slashes_to_index_array(size_t* a, const char *path);
It is not checked, if more than PATH_MAX_LEVEL -1 slashes are in the path.
Addet peer_name to tg_peer_t, which represents the orginal peer name.
print_name is now a escaped version which replaced all slash by underscore.